### PR TITLE
Add correct install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ Three editing modes now exist: Jupyter command, Vim command, and Vim insert.
 ### Install or upgrade
 
 ```bash
-jupyter labextension install jupyterlab_vim
+jupyter labextension install @axlair/jupyterlab_vim
 ```
 
 ### Uninstall
 
 ```bash
-jupyter labextension uninstall jupyterlab_vim
+jupyter labextension uninstall @axlair/jupyterlab_vim
 ```
 
 ## Key Bindings


### PR DESCRIPTION
Your repo is currently the first jupyterlab_vim extension that someone will find when looking for a jlab2 compatible version. So I updated the install instructions to make them copy pasteable.

I didn't add to history because its not clear if this warrants an entry there?
- [ ] Add a line to `History.md` briefly documenting the change.

