### PR TITLE
Added "Folding" Keybindings

### DIFF
--- a/History.md
+++ b/History.md
@@ -2,10 +2,10 @@
 
 ## 0.12.2 / 2020-04-25
 
-  * `z c` hides selected cell code
-  * `z o` shows selected cell code
-  * `z m` hides all cell code
-  * `z r` shows all cell code
+  * `z c` hides selected code cell
+  * `z o` shows selected code cell
+  * `z m` hides all code cells
+  * `z r` shows all code cells
 
 
 ## 0.12.1 / 2020-03-06

--- a/History.md
+++ b/History.md
@@ -1,5 +1,13 @@
 # History
 
+## 0.12.2 / 2020-04-25
+
+  * `z c` hides selected cell code
+  * `z o` shows selected cell code
+  * `z m` hides all cell code
+  * `z r` shows all cell code
+
+
 ## 0.12.1 / 2020-03-06
 
   * `ctrl [` exits Vim insert mode

--- a/README.md
+++ b/README.md
@@ -93,6 +93,10 @@ Shortcuts this extension introduces:
 | Ctrl-E  | Move Cells Down   |
 | Ctrl-Y  | Move Cells Up     |
 | Z, Z    | Center Cell       |
+| Z, C    | Hide Cell Code    |
+| Z, O    | Show Cell Code    |
+| Z, M    | Hide All Code     |
+| Z, R    | Show All Code     |
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -93,10 +93,10 @@ Shortcuts this extension introduces:
 | Ctrl-E  | Move Cells Down   |
 | Ctrl-Y  | Move Cells Up     |
 | Z, Z    | Center Cell       |
-| Z, C    | Hide Cell Code    |
-| Z, O    | Show Cell Code    |
-| Z, M    | Hide All Code     |
-| Z, R    | Show All Code     |
+| Z, C    | Hide Code Cell |
+| Z, O    | Show Code Cell |
+| Z, M    | Hide All Code Cells |
+| Z, R    | Show All Code Cells  |
 
 ## Contributing
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jupyterlab_vim",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "Code cell vim bindings",
   "author": "Jacques Kvam",
   "license": "MIT",

--- a/src/index.ts
+++ b/src/index.ts
@@ -594,6 +594,26 @@ function activateCellVim(app: JupyterFrontEnd, tracker: INotebookTracker): Promi
             command: 'center-cell'
         });
         commands.addKeyBinding({
+            selector: '.jp-Notebook:focus',
+            keys: ['Z', 'C'],
+            command: 'notebook:hide-cell-code'
+        });
+        commands.addKeyBinding({
+            selector: '.jp-Notebook:focus',
+            keys: ['Z', 'O'],
+            command: 'notebook:show-cell-code'
+        });
+        commands.addKeyBinding({
+            selector: '.jp-Notebook:focus',
+            keys: ['Z', 'M'],
+            command: 'notebook:hide-all-cell-code'
+        });
+        commands.addKeyBinding({
+            selector: '.jp-Notebook:focus',
+            keys: ['Z', 'R'],
+            command: 'notebook:show-all-cell-code'
+        });
+        commands.addKeyBinding({
             selector: '.jp-Notebook.jp-mod-editMode',
             keys: ['Ctrl O', 'Z', 'Z'],
             command: 'center-cell'


### PR DESCRIPTION
I've added the following keybindings to hide and show code blocks analogous to vim folding.
* `Z, C` hides the code in the selected cell
* `Z, O` shows the code in the selected cell
* `Z, M` hides the code in all cells
* `Z, R` shows the code in all cells

I also bumped the version and added these shortcuts to `README.md`. 

