### PR TITLE
Add binder bot that will comment on PRs

### DIFF
--- a/.github/workflows/bind-on-pr.yaml
+++ b/.github/workflows/bind-on-pr.yaml
@@ -1,0 +1,26 @@
+# Reference https://mybinder.readthedocs.io/en/latest/howto/gh-actions-badges.html
+name: Binder Badge
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  binder:
+    runs-on: ubuntu-latest
+    steps:
+    - name: comment on PR with Binder link
+      uses: actions/github-script@v1
+      with:
+        github-token: ${{secrets.GITHUB_TOKEN}}
+        script: |
+          var PR_HEAD_USERREPO = process.env.PR_HEAD_USERREPO;
+          var PR_HEAD_REF = process.env.PR_HEAD_REF;
+          github.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: `[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/${PR_HEAD_USERREPO}/${PR_HEAD_REF}?urlpath=lab) :point_left: Launch a binder notebook on branch _${PR_HEAD_USERREPO}/${PR_HEAD_REF}_`
+          })
+      env:
+        PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        PR_HEAD_USERREPO: ${{ github.event.pull_request.head.repo.full_name }}


### PR DESCRIPTION
Adds a binder bot that will comment on PRs with a link to a binder based on the PR's branch. This makes it easier to review.
